### PR TITLE
Remove clientId from JWKS request

### DIFF
--- a/src/ServiceProvider/OAuth/Middleware/OpenIdConnectMiddlewareService.php
+++ b/src/ServiceProvider/OAuth/Middleware/OpenIdConnectMiddlewareService.php
@@ -121,7 +121,7 @@ class OpenIdConnectMiddlewareService implements OAuthMiddlewareServiceInterface 
         $jwks = null;
         $keysUri = $this->oidc->getIdentityProviderJsonWebKeySetUri();
         if($keysUri !== null) {
-            $jwks = $this->getRemoteJsonWebKeySet($keysUri, $clientId);
+            $jwks = $this->getRemoteJsonWebKeySet($keysUri);
         }
         if($jwks === null) {
 
@@ -175,7 +175,7 @@ class OpenIdConnectMiddlewareService implements OAuthMiddlewareServiceInterface 
                 $this->logger->warning('Verification failed, invalidating cached JSON web key set (JWKS)...');
 
                 // try one more time with remote source, and force a cache invalidation
-                $jwks = $this->getRemoteJsonWebKeySet($keysUri, $clientId, true);
+                $jwks = $this->getRemoteJsonWebKeySet($keysUri, true);
                 if($jwks === null) {
                     throw new OpenIdConnectMiddlewareServiceCannotLoadJsonWebKeySetException();
                 }
@@ -289,12 +289,10 @@ class OpenIdConnectMiddlewareService implements OAuthMiddlewareServiceInterface 
 
     /**
      * @param XUri $keysUri - remote JWKS lookup service URL
-     * @param string $clientId - OAuth client ID
      * @param bool $ignoreCachedResult - use a remote connection, ignoring the cache
      */
-    private function getRemoteJsonWebKeySet(XUri $keysUri, string $clientId, bool $ignoreCachedResult = false) : ?JWKSet {
+    private function getRemoteJsonWebKeySet(XUri $keysUri, bool $ignoreCachedResult = false) : ?JWKSet {
         $jwks = null;
-        $keysUri = $keysUri->with(OAuthFlowService::PARAM_CLIENT_ID, $clientId);
         $this->logger->debug('Fetching JSON web key set (JWKS) from cached keys endpoint response...', [
             'Url' => $keysUri->toString()
         ]);

--- a/tests/ServiceProvider/OAuth/OAuthFlowService/OpenIdConnect/getAuthenticatedUri/RemoteJsonWebKeysTest.php
+++ b/tests/ServiceProvider/OAuth/OAuthFlowService/OpenIdConnect/getAuthenticatedUri/RemoteJsonWebKeysTest.php
@@ -335,7 +335,7 @@ class RemoteJsonWebKeysTest extends AbstractOAuthTestCase {
         }
         MockPlug::register(
             (new MockRequestMatcher(Plug::METHOD_GET,
-                $identityProviderJsonWebKeySetUri->with('client_id', $relyingPartyClientId)
+                $identityProviderJsonWebKeySetUri
             )),
             (new Result())
                 ->withStatus(200)
@@ -388,7 +388,7 @@ class RemoteJsonWebKeysTest extends AbstractOAuthTestCase {
         static::assertTrue(MockPlug::verifyAll());
         static::assertEquals('https://app.example.com/dashboard', $result->toString());
         static::assertNotNull($remoteKeysCacheKeyUri);
-        static::assertEquals($remoteKeysCacheKeyUri->toString(), $identityProviderJsonWebKeySetUri->with('client_id', $relyingPartyClientId)->toString());
+        static::assertEquals($remoteKeysCacheKeyUri->toString(), $identityProviderJsonWebKeySetUri->toString());
         static::assertCount(1, $events);
         $event = $events[0];
         static::assertEquals(1_531_406_335, $event->getDateTime()->getTimestamp());


### PR DESCRIPTION
Client id is not required for JWKS requests.  This causes errors for Azure's OIDC integration.

As of [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517), JSON Web Key Set (JWKS) specification itself doesn't include a requirement to include a `client_id` in a JWKS HTTP GET request. 

JWKS is typically used in the context of OAuth 2.0 and OpenID Connect (OIDC) protocols. In these protocols, the `client_id` is usually used to identify the client application making requests to the authorization server, and it's included in the initial authorization request rather than in the JWKS request.

There could be custom implementations or additional parameters required for JWKS retrieval.  After reviewing Okta, OneLogin, and current requests in DataDog, its not required by any known customers.