### PR TITLE
Handle Errors the same

### DIFF
--- a/src/ServiceProvider/Saml/SamlUriFactory.php
+++ b/src/ServiceProvider/Saml/SamlUriFactory.php
@@ -182,6 +182,15 @@ class SamlUriFactory implements SamlUriFactoryInterface {
      * @throws SamlCannotGenerateSignatureException
      */
     private function withSignature(xUri $uri, CryptoKeyInterface $key, string $algo = XMLSecurityKey::RSA_SHA1) : xUri {
+        if (StringEx::isNullOrEmpty($key->toString())) {
+            throw new SamlCannotGenerateSignatureException();
+        }
+
+        $cert = $this->saml->getServiceProviderX509Certificate();
+        if ($cert === null) {
+            throw new SamlCannotGenerateSignatureException();
+        }
+
         $msg = '';
 
         $request = $uri->getQueryParam(HttpMessageInterface::PARAM_SAML_REQUEST);
@@ -212,7 +221,11 @@ class SamlUriFactory implements SamlUriFactoryInterface {
             throw new SamlCannotLoadCryptoKeyException($key, $e->getMessage());
         }
 
-        $signature = $signer->signData($msg);
+        try {
+            $signature = $signer->signData($msg);
+        } catch (Exception $e) {
+            throw new SamlCannotGenerateSignatureException();
+        }
         if ($signature === null) {
             throw new SamlCannotGenerateSignatureException();
         }


### PR DESCRIPTION
Handle errors the same way the deprecated function was. Had some tests that were failing due to a different error being thrown than the one that was expected.