### PR TITLE
PKCE was working when it was an SP initiated login but IdP initiated login was not working

### DIFF
--- a/src/ServiceProvider/OAuth/OAuthFlowService.php
+++ b/src/ServiceProvider/OAuth/OAuthFlowService.php
@@ -123,14 +123,16 @@ class OAuthFlowService implements AuthFlowServiceInterface {
             self::PARAM_REDIRECT_URI => $this->oauth->getAuthorizationCodeConsumerUri()->toString()
         ];
 
-        if($this->oauth->getPCKEEnabled()){
+        if ($this->oauth->getPCKEEnabled()) {
             $baseCodeVerifier = $this->sessionStorage->getVal(self::SESSION_OAUTH_CODE_VERIFIER);
-            if(!StringEx::isNullOrEmpty($baseCodeVerifier)) {
+
+            if (!StringEx::isNullOrEmpty($baseCodeVerifier) && !StringEx::isNullOrEmpty($state)) {
                 $encodedState = $this->base64UrlEncode($state);
                 $codeVerifier = $baseCodeVerifier . $encodedState;
                 $tokenFormDataParameterValuePairs[self::SESSION_OAUTH_CODE_VERIFIER] = $codeVerifier;
             }
         }
+
         $tokenUri = $this->oauth->getIdentityProviderTokenUri();
         $clientId = $this->oauth->getRelyingPartyClientId();
         $clientSecret = $this->oauth->getRelyingPartyClientSecret();


### PR DESCRIPTION
From some research and learnings IdP initiated login does NOT enforce PKCE. This is because the user has already been authenticated with the IdP and there is no need for this. On an SP initiated flow the user has not been authenticated and therefore a PKCE is required. 

A quick check for this is if state is present or not. State is only present when it is a SP initiated flow, and not in an IdP initiated flow. So before this fix SP initiated flow was working, but IdP initiated flow was not working. This was because it was trying to encode a `null` state and failing out. Just simply checking for this and not encoding state fixed the issue.

EXTRA: I noticed that we concatenate `state` with the `codeVerifier` which apparently isn't compatible with PKCE. When I tried to remove this concatenation I received a 403 when trying to login through the SP initiated flow. This leads me to believe that we concatenate this somewhere and that is what cognito expects so when I unconcatenated it, it no longer worked. Not sure what we want to do here about this but this does work with the flow that we have set.