### PR TITLE
Fix state value and update authentication logic

### DIFF
--- a/src/ServiceProvider/OAuth/OAuthFlowService.php
+++ b/src/ServiceProvider/OAuth/OAuthFlowService.php
@@ -85,14 +85,11 @@ class OAuthFlowService implements AuthFlowServiceInterface {
     public function getAuthenticatedUri(ServerRequestEx $request) : XUri {
         $this->logger->debug('Processing authorization code response...');
 
-        // OAuth 2.0 authorization code flow incorporates HTTP GET requests only, therefore it is safe to assume all parameters are query parameters
         $params = $request->getQueryParams();
 
-        // fetch return href
         $returnHref = StringEx::stringify($this->sessionStorage->getVal(self::SESSION_OAUTH_HREF));
         $this->sessionStorage->setVal(self::SESSION_OAUTH_HREF);
 
-        // check session state
         $state = $params->get(self::PARAM_STATE);
         $sessionState = $this->sessionStorage->getVal(self::SESSION_OAUTH_STATE);
         $this->sessionStorage->setVal(self::SESSION_OAUTH_STATE);
@@ -124,18 +121,16 @@ class OAuthFlowService implements AuthFlowServiceInterface {
         ];
 
         if ($this->oauth->getPCKEEnabled()) {
-            $baseCodeVerifier = $this->sessionStorage->getVal(self::SESSION_OAUTH_CODE_VERIFIER);
-
-            if (!StringEx::isNullOrEmpty($baseCodeVerifier) && !StringEx::isNullOrEmpty($state)) {
-                $encodedState = $this->base64UrlEncode($state);
-                $codeVerifier = $baseCodeVerifier . $encodedState;
-                $tokenFormDataParameterValuePairs[self::SESSION_OAUTH_CODE_VERIFIER] = $codeVerifier;
+            $fullCodeVerifier = $this->sessionStorage->getVal(self::SESSION_OAUTH_CODE_VERIFIER);
+            if (!StringEx::isNullOrEmpty($fullCodeVerifier)) {
+                $tokenFormDataParameterValuePairs[self::SESSION_OAUTH_CODE_VERIFIER] = $fullCodeVerifier;
             }
         }
 
         $tokenUri = $this->oauth->getIdentityProviderTokenUri();
         $clientId = $this->oauth->getRelyingPartyClientId();
         $clientSecret = $this->oauth->getRelyingPartyClientSecret();
+
         try {
             $tokenResult = match ($this->oauth->getIdentityProviderTokenClientAuthenticationMethod()) {
                 self::TOKEN_AUTH_METHOD_CLIENT_SECRET_POST => $this->newPlug($tokenUri)
@@ -171,7 +166,7 @@ class OAuthFlowService implements AuthFlowServiceInterface {
                 'StatusCode' => $tokenResult->getStatus()
             ]);
         }
-        $this->sessionStorage->getVal(self::SESSION_OAUTH_CODE_VERIFIER);
+
         $claims = $this->middlewareService->getClaims($tokenResult);
         $username = $claims->getUsername();
         if(StringEx::isNullOrEmpty($username)) {
@@ -201,8 +196,14 @@ class OAuthFlowService implements AuthFlowServiceInterface {
      */
     public function getLoginUri(XUri $returnUri, string $securityKey) : XUri {
         $clientId = $this->oauth->getRelyingPartyClientId();
-        $state = $this->uuidFactory->uuid4()->toString();
+        $returnHref = $returnUri->toString();
+        $redirectUri = $this->oauth->getAuthorizationCodeConsumerUri()->toString();
+        // Generate state (either UUID or the return URL)
+        $state = str_contains($redirectUri, "code")
+            ? $this->uuidFactory->uuid4()->toString()
+            : $returnHref;
         $encodedState = $this->base64UrlEncode($state);
+
         $uri = $this->oauth->getIdentityProviderAuthorizationUri()
             ->withoutQueryParams([
                 self::PARAM_CLIENT_ID,
@@ -212,39 +213,37 @@ class OAuthFlowService implements AuthFlowServiceInterface {
                 self::PARAM_SCOPE
             ])
             ->with(self::PARAM_CLIENT_ID, $clientId)
-            ->with(self::PARAM_REDIRECT_URI, $this->oauth->getAuthorizationCodeConsumerUri()->toString())
+            ->with(self::PARAM_REDIRECT_URI, $redirectUri)
             ->with(self::PARAM_RESPONSE_TYPE, 'code')
-            ->with(self::PARAM_STATE, $state);
-        if($this->oauth->getPCKEEnabled()){
+            ->with(self::PARAM_STATE, $encodedState);
+
+        if ($this->oauth->getPCKEEnabled()) {
             $baseCodeVerifier = $this->generateCodeVerifier();
-            $codeVerifier = $baseCodeVerifier . $encodedState;
-            $codeChallenge = $this->generateCodeChallenge($codeVerifier);
+            $fullCodeVerifier = $baseCodeVerifier . $encodedState;
+
+            $codeChallenge = $this->generateCodeChallenge($fullCodeVerifier);
+
             $uri = $uri->with(self::PARAM_CODE_CHALLENGE, $codeChallenge)
                 ->with(self::PARAM_CODE_CHALLENGE_METHOD, 'S256');
 
-            // TODO this needs to reviewed closer.
-            $this->sessionStorage->setVal(self::PARAM_CODE_CHALLENGE, $codeChallenge);
-            $this->sessionStorage->setVal(self::SESSION_OAUTH_CODE_VERIFIER, $baseCodeVerifier);
+            $this->sessionStorage->setVal(self::SESSION_OAUTH_CODE_VERIFIER, $fullCodeVerifier);
         }
 
-        // scope
         $scopes = array_unique(array_merge($this->middlewareService->getScopes(), $this->oauth->getScopes()));
         $uri = $uri->with(self::PARAM_SCOPE, implode(' ', $scopes));
 
-        // store session state
-        $returnHref = $returnUri->toString();
+        // Store the return URL and encoded state in session
         $this->sessionStorage->setVal(self::SESSION_OAUTH_HREF, $returnHref);
-        $this->sessionStorage->setVal(self::SESSION_OAUTH_STATE, $state);
+        $this->sessionStorage->setVal(self::SESSION_OAUTH_STATE, $encodedState);
         $this->logger->debug('Generating authorization code request', [
             'AuthorizeEndpointUrl' => $uri->toString(),
             'ClientId' => $clientId,
             'ReturnUrl' => $returnHref,
             'Scopes' => $scopes,
-            'State' => $state
+            'State' => $encodedState
         ]);
         return $uri;
     }
-
     public function getLogoutUri(string $id, XUri $returnUri) : ?XUri {
         return $this->middlewareService->getLogoutUri($id, $returnUri);
     }


### PR DESCRIPTION
There were really only 2 problems here in AuthForge and the first was that when using the global redirector we weren't using the `returnUri` parameter as the state value and encoding it. We were still only using the random UUID as state and therefore we did not know where we were going to redirect the user once they were finally logged in. This has now been fixed to check if the `returnUri` has `code` in it and therefore it is NOT using global redirector. Otherwise use the random UUID.

The second problem was a mismatch between `getAuthenticatedUri` and `getLoginURi` so I cleaned up some logic a bit specifically when relating to PKCE. Previously we were generating the `baseCodeVerifier` and the `codeChallenge` and storing it in session storage. I have removed storing the `codeChallenge` entirely as the IDP stores the `codeChallenge` and we don't actually need to use it anywhere else. Also Instead of storing the `baseCodeVerifier` I now store `fullCodeVerifier` which is the `baseCodeVerifier` and the `encodedState` together. 

Previously we were only storing the `baseCodeVerifier` then trying to re put it all back together in `getAuthenticatedUri` and compare it that way, but this was unnecessary. By just storing the `fullCodeVerifier` then retrieving it in `getAuthenticatedUri` we then send that along and use it as verification instead of trying to reconstruct the `fullCodeVerifier` again (like we were doing before) and verifying that way. There was a mismatch in logic here, so I cut out an the unnecessary steps of reconstruction. This still protects against the tampering of `state` and `code` and if either of those change then PKCE will fail.