### PR TITLE
Update getLoginUri to encode service name in state

### DIFF
--- a/src/ServiceProvider/AuthFlowServiceInterface.php
+++ b/src/ServiceProvider/AuthFlowServiceInterface.php
@@ -32,7 +32,7 @@ interface AuthFlowServiceInterface {
      * @param string $securityKey
      * @return XUri
      */
-    public function getLoginUri(XUri $returnUri, string $securityKey) : XUri;
+    public function getLoginUri(XUri $returnUri, string $securityKey, string $serviceName) : XUri;
 
     /**
      * @param string $id - user identifier for downstream identity provider

--- a/src/ServiceProvider/OAuth/OAuthFlowService.php
+++ b/src/ServiceProvider/OAuth/OAuthFlowService.php
@@ -194,14 +194,24 @@ class OAuthFlowService implements AuthFlowServiceInterface {
      * @return XUri The constructed login URI with necessary query parameters for OAuth 2.0 authorization code flow.
      * @throws RandomException
      */
-    public function getLoginUri(XUri $returnUri, string $securityKey) : XUri {
+    public function getLoginUri(XUri $returnUri, string $securityKey, string $serviceName) : XUri {
         $clientId = $this->oauth->getRelyingPartyClientId();
         $returnHref = $returnUri->toString();
+
+        $returnUriForState = $returnUri;
+        if (!StringEx::isNullOrEmpty($serviceName)) {
+            $returnUriForState = XUri::newFromString($returnHref)
+                ->with('name', $serviceName);
+        }
+
+        $returnHrefForState = $returnUriForState->toString();
+
         $redirectUri = $this->oauth->getAuthorizationCodeConsumerUri()->toString();
-        // Generate state (either UUID or the return URL)
+        // Generate state (either UUID or the return URL. Code is included in non Global Redirect)
         $state = str_contains($redirectUri, "code")
             ? $this->uuidFactory->uuid4()->toString()
-            : $returnHref;
+            : $returnHrefForState;
+
         $encodedState = $this->base64UrlEncode($state);
 
         $uri = $this->oauth->getIdentityProviderAuthorizationUri()
@@ -232,16 +242,18 @@ class OAuthFlowService implements AuthFlowServiceInterface {
         $scopes = array_unique(array_merge($this->middlewareService->getScopes(), $this->oauth->getScopes()));
         $uri = $uri->with(self::PARAM_SCOPE, implode(' ', $scopes));
 
-        // Store the return URL and encoded state in session
         $this->sessionStorage->setVal(self::SESSION_OAUTH_HREF, $returnHref);
         $this->sessionStorage->setVal(self::SESSION_OAUTH_STATE, $encodedState);
+
         $this->logger->debug('Generating authorization code request', [
             'AuthorizeEndpointUrl' => $uri->toString(),
             'ClientId' => $clientId,
             'ReturnUrl' => $returnHref,
             'Scopes' => $scopes,
-            'State' => $encodedState
+            'State' => $encodedState,
+            'ServiceName' => $serviceName
         ]);
+
         return $uri;
     }
     public function getLogoutUri(string $id, XUri $returnUri) : ?XUri {


### PR DESCRIPTION
Pass the `service-name` to the `getLoginUri` function, and encode the service name in the state. However store the regular `returnUri` (without the name parameter) in the session storage [here](https://github.com/MindTouch/AuthForge/pull/22/files#diff-2ffb74b5a2e9dfdc475e749a7575115546015c9d7737ba181e4645b54a191b21R245). Basically leave it as is instead of changing it to store the URL with the name parameter. If we store the `returnUriForState` in the session storage, then after authentication and its final redirect the URL will look like this `https://testpercy3.mindtouch.be?name=nice`. I figured this was not the ideal scenario or what we wanted so by storing just  `https://testpercy3.mindtouch.be`. 

This still follows all PKCE and OAuth rules it just allows for the redirect URL at the very end to be clean AFTER authentication and redirection from the lambda. This is pulled to redirect the user to their site in `getAuthenticatedUri` [here](https://github.com/MindTouch/AuthForge/pull/22/files#diff-2ffb74b5a2e9dfdc475e749a7575115546015c9d7737ba181e4645b54a191b21L90), so only storing what it finally should be is just fine.