### PR TITLE
Fix SamlFlowService.php. This file also pulls getLoginUri and was having a syntax error

### DIFF
--- a/src/ServiceProvider/Saml/SamlFlowService.php
+++ b/src/ServiceProvider/Saml/SamlFlowService.php
@@ -183,9 +183,12 @@ class SamlFlowService implements AuthFlowServiceInterface {
 
     /**
      * {@inheritDoc}
+     * @param XUri $returnUri
+     * @param string $securityKey
+     * @param string $serviceName
      * @throws SamlFlowServiceException
      */
-    public function getLoginUri(XUri $returnUri, string $securityKey) : XUri {
+    public function getLoginUri(XUri $returnUri, string $securityKey, string $serviceName) : XUri {
         try {
             return $this->uriFactory->newAuthnRequestUri($returnUri, $securityKey);
         } catch(


### PR DESCRIPTION
I didn't know there was another file that inherited the function that I changed in my previous PR. Saw that there were PHP tests failing in my PR in deki, and it was because this function didn't have the correct signature. The saml version of this function doesn't need the `servicename` but they both inherit from the same interface. `AuthFlowServiceInterface.php`

This fixes the files that were failing to run due to an incorrect signature.